### PR TITLE
Allow GenericMessage subclasses to provide headers

### DIFF
--- a/spring-context/src/main/java/org/springframework/messaging/GenericMessage.java
+++ b/spring-context/src/main/java/org/springframework/messaging/GenericMessage.java
@@ -68,6 +68,20 @@ public class GenericMessage<T> implements Message<T>, Serializable {
 		this.payload = payload;
 	}
 
+	/**
+	 * Create a new message with the given message headers and payload.
+	 * The message headers will be used as-is.
+	 *
+	 * @param messageHeaders message headers
+	 * @param payload the message payload
+	 */
+	protected GenericMessage(MessageHeaders messageHeaders, T payload) {
+		Assert.notNull(messageHeaders, "messageHeaders must not be null");
+		Assert.notNull(payload, "payload must not be null");
+
+		this.headers = messageHeaders;
+		this.payload = payload;
+	}
 
 	public MessageHeaders getHeaders() {
 		return this.headers;


### PR DESCRIPTION
A GenericMessage subclass may want to use a MessageHeaders subclass
to store its headers. To enable this, add a constructor to
GenericMessage that takes a MessageHeaders instance and uses the
headers as-is.
