### PR TITLE
Genericize PubSubChannelRegistry

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/messaging/PubSubChannelRegistry.java
+++ b/spring-websocket/src/main/java/org/springframework/web/messaging/PubSubChannelRegistry.java
@@ -25,12 +25,12 @@ import org.springframework.messaging.SubscribableChannel;
  * @author Rossen Stoyanchev
  * @since 4.0
  */
-public interface PubSubChannelRegistry {
+public interface PubSubChannelRegistry<M extends Message<?>, H extends MessageHandler<M>> {
 
-	SubscribableChannel<Message<?>, MessageHandler<Message<?>>> getClientInputChannel();
+	SubscribableChannel<M, H> getClientInputChannel();
 
-	SubscribableChannel<Message<?>, MessageHandler<Message<?>>> getClientOutputChannel();
+	SubscribableChannel<M, H> getClientOutputChannel();
 
-	SubscribableChannel<Message<?>, MessageHandler<Message<?>>> getMessageBrokerChannel();
+	SubscribableChannel<M, H> getMessageBrokerChannel();
 
 }

--- a/spring-websocket/src/main/java/org/springframework/web/messaging/support/AbstractPubSubChannelRegistry.java
+++ b/spring-websocket/src/main/java/org/springframework/web/messaging/support/AbstractPubSubChannelRegistry.java
@@ -28,39 +28,38 @@ import org.springframework.web.messaging.PubSubChannelRegistry;
  * @author Rossen Stoyanchev
  * @since 4.0
  */
-public class AbstractPubSubChannelRegistry implements PubSubChannelRegistry, InitializingBean {
+public class AbstractPubSubChannelRegistry<M extends Message<?>, H extends MessageHandler<M>> implements PubSubChannelRegistry<M, H>, InitializingBean {
 
-	private SubscribableChannel<Message<?>, MessageHandler<Message<?>>> clientInputChannel;
+	private SubscribableChannel<M, H> clientInputChannel;
 
-	private SubscribableChannel<Message<?>, MessageHandler<Message<?>>> clientOutputChannel;
+	private SubscribableChannel<M, H> clientOutputChannel;
 
-	private SubscribableChannel<Message<?>, MessageHandler<Message<?>>> messageBrokerChannel;
+	private SubscribableChannel<M, H> messageBrokerChannel;
 
+	@Override
+	public SubscribableChannel<M, H> getClientInputChannel() {
+		return this.clientInputChannel;
+	}
 
-	public void setClientInputChannel(SubscribableChannel<Message<?>, MessageHandler<Message<?>>> channel) {
+	public void setClientInputChannel(SubscribableChannel<M, H> channel) {
 		this.clientInputChannel = channel;
 	}
 
 	@Override
-	public SubscribableChannel<Message<?>, MessageHandler<Message<?>>> getClientInputChannel() {
-		return this.clientInputChannel;
-	}
-
-	@Override
-	public SubscribableChannel<Message<?>, MessageHandler<Message<?>>> getClientOutputChannel() {
+	public SubscribableChannel<M, H> getClientOutputChannel() {
 		return this.clientOutputChannel;
 	}
 
-	public void setClientOutputChannel(SubscribableChannel<Message<?>, MessageHandler<Message<?>>> channel) {
+	public void setClientOutputChannel(SubscribableChannel<M, H> channel) {
 		this.clientOutputChannel = channel;
 	}
 
 	@Override
-	public SubscribableChannel<Message<?>, MessageHandler<Message<?>>> getMessageBrokerChannel() {
+	public SubscribableChannel<M, H> getMessageBrokerChannel() {
 		return this.messageBrokerChannel;
 	}
 
-	public void setMessageBrokerChannel(SubscribableChannel<Message<?>, MessageHandler<Message<?>>> channel) {
+	public void setMessageBrokerChannel(SubscribableChannel<M, H> channel) {
 		this.messageBrokerChannel = channel;
 	}
 

--- a/spring-websocket/src/main/java/org/springframework/web/messaging/support/ReactorPubSubChannelRegistry.java
+++ b/spring-websocket/src/main/java/org/springframework/web/messaging/support/ReactorPubSubChannelRegistry.java
@@ -16,6 +16,8 @@
 
 package org.springframework.web.messaging.support;
 
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
 
 import reactor.core.Reactor;
@@ -25,8 +27,7 @@ import reactor.core.Reactor;
  * @author Rossen Stoyanchev
  * @since 4.0
  */
-public class ReactorPubSubChannelRegistry extends AbstractPubSubChannelRegistry {
-
+public class ReactorPubSubChannelRegistry extends AbstractPubSubChannelRegistry<Message<?>, MessageHandler<Message<?>>> {
 
 	public ReactorPubSubChannelRegistry(Reactor reactor) {
 


### PR DESCRIPTION
Without generics, extending AbstractPubSubChannelRegistry and using
a custom Message type requires some unpleasant casting and suppression
of warnings. By genericizing PubSubChannelRegistry and
AbstractPubSubChannelRegistry these problems can be avoided.
