### PR TITLE
Received message's destination is default for resp

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/messaging/service/method/MessageReturnValueHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/messaging/service/method/MessageReturnValueHandler.java
@@ -84,6 +84,10 @@ public class MessageReturnValueHandler implements ReturnValueHandler {
 		returnHeaders.setSessionId(sessionId);
 		returnHeaders.setSubscriptionId(subscriptionId);
 
+		if (returnHeaders.getDestination() == null) {
+			returnHeaders.setDestination(headers.getDestination());
+		}
+
 		Object payload = returnMessage.getPayload();
 		return MessageBuilder.fromPayloadAndHeaders(payload, returnHeaders.toMessageHeaders()).build();
 	}


### PR DESCRIPTION
When an annotated handler returns a Message from a @SubscribeEvent
or @MessageMapping method and it contains no destination in its
headers, use the received message's destination as the response
message's destination.
