### PR TITLE
Fix typo in MessageHeaderAccessor's class name

### DIFF
--- a/spring-context/src/main/java/org/springframework/messaging/support/MessageBuilder.java
+++ b/spring-context/src/main/java/org/springframework/messaging/support/MessageBuilder.java
@@ -34,7 +34,7 @@ public final class MessageBuilder<T> {
 
 	private final T payload;
 
-	private final MessageHeaderAccesssor headerAccessor;
+	private final MessageHeaderAccessor headerAccessor;
 
 	private final Message<T> originalMessage;
 
@@ -46,7 +46,7 @@ public final class MessageBuilder<T> {
 		Assert.notNull(payload, "payload must not be null");
 		this.payload = payload;
 		this.originalMessage = originalMessage;
-		this.headerAccessor = new MessageHeaderAccesssor(originalMessage);
+		this.headerAccessor = new MessageHeaderAccessor(originalMessage);
 	}
 
 	/**

--- a/spring-context/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
+++ b/spring-context/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
@@ -37,7 +37,7 @@ import org.springframework.util.StringUtils;
  * A base class for read/write access to {@link MessageHeaders}. Supports creation of new
  * headers or modification of existing message headers.
  * <p>
- * Sub-classes can provide additinoal typed getters and setters for convenient access to
+ * Sub-classes can provide additional typed getters and setters for convenient access to
  * specific headers. Getters and setters should delegate to {@link #getHeader(String)} or
  * {@link #setHeader(String, Object)} respectively. At the end {@link #toMap()} can be
  * used to obtain the resulting headers.
@@ -45,7 +45,7 @@ import org.springframework.util.StringUtils;
  * @author Rossen Stoyanchev
  * @since 4.0
  */
-public class MessageHeaderAccesssor {
+public class MessageHeaderAccessor {
 
 	protected Log logger = LogFactory.getLog(getClass());
 
@@ -60,14 +60,14 @@ public class MessageHeaderAccesssor {
 	/**
 	 * A constructor for creating new message headers.
 	 */
-	public MessageHeaderAccesssor() {
+	public MessageHeaderAccessor() {
 		this.originalHeaders = null;
 	}
 
 	/**
 	 * A constructor for accessing and modifying existing message headers.
 	 */
-	public MessageHeaderAccesssor(Message<?> message) {
+	public MessageHeaderAccessor(Message<?> message) {
 		this.originalHeaders = (message != null) ? message.getHeaders() : null;
 	}
 

--- a/spring-context/src/main/java/org/springframework/messaging/support/NativeMessageHeaderAccessor.java
+++ b/spring-context/src/main/java/org/springframework/messaging/support/NativeMessageHeaderAccessor.java
@@ -28,14 +28,14 @@ import org.springframework.util.ObjectUtils;
 
 
 /**
- * An extension of {@link MessageHeaderAccesssor} that also provides read/write access to
+ * An extension of {@link MessageHeaderAccessor} that also provides read/write access to
  * message headers from an external message source. Native message headers are kept
  * in a {@link MultiValueMap} under the key {@link #NATIVE_HEADERS}.
  *
  * @author Rossen Stoyanchev
  * @since 4.0
  */
-public class NativeMessageHeaderAccessor extends MessageHeaderAccesssor {
+public class NativeMessageHeaderAccessor extends MessageHeaderAccessor {
 
 
 	public static final String NATIVE_HEADERS = "nativeHeaders";


### PR DESCRIPTION
Remove the extra 's' from the class name
