### PR TITLE
Verify types when setting header

### DIFF
--- a/spring-context/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
+++ b/spring-context/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
@@ -113,6 +113,7 @@ public class MessageHeaderAccessor {
 	 */
 	public void setHeader(String name, Object value) {
 		Assert.isTrue(!isReadOnly(name), "The '" + name + "' header is read-only.");
+		verifyType(name, value);
 		if (!ObjectUtils.nullSafeEquals(value, getHeader(name))) {
 			this.headers.put(name, value);
 		}
@@ -209,11 +210,19 @@ public class MessageHeaderAccessor {
 		setHeader(MessageHeaders.ERROR_CHANNEL, errorChannelName);
 	}
 
-
 	@Override
 	public String toString() {
 		return getClass().getSimpleName() + " [originalHeaders=" + this.originalHeaders
 				+ ", updated headers=" + this.headers + "]";
 	}
 
+	protected void verifyType(String headerName, Object headerValue) {
+        if (headerName != null && headerValue != null) {
+        	if (MessageHeaders.ERROR_CHANNEL.equals(headerName)
+                    || MessageHeaders.REPLY_CHANNEL.endsWith(headerName)) {
+                Assert.isTrue(headerValue instanceof MessageChannel || headerValue instanceof String, "The '"
+                        + headerName + "' header value must be a MessageChannel or String.");
+            }
+        }
+    }
 }


### PR DESCRIPTION
When a header is being set, verify that the type that's provided is
legal for the header that's been set. For example, the error channel's
type must be a MessageChannel or a String.

The method that performs type verification is protected so that it
can be overriden by sub-classes. It is expected that an overriding
method will call the super method.
