### PR TITLE
Consider original headers in pattern-based removal

### DIFF
--- a/spring-context/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
+++ b/spring-context/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
@@ -141,11 +141,8 @@ public class MessageHeaderAccessor {
 		for (String pattern : headerPatterns) {
 			if (StringUtils.hasLength(pattern)){
 				if (pattern.contains("*")){
-					for (String headerName : this.headers.keySet()) {
-						if (PatternMatchUtils.simpleMatch(pattern, headerName)){
-							headersToRemove.add(headerName);
-						}
-					}
+					headersToRemove.addAll(getMatchingHeaderNames(pattern, this.headers));
+					headersToRemove.addAll(getMatchingHeaderNames(pattern, this.originalHeaders));
 				}
 				else {
 					headersToRemove.add(pattern);
@@ -155,6 +152,18 @@ public class MessageHeaderAccessor {
 		for (String headerToRemove : headersToRemove) {
 			removeHeader(headerToRemove);
 		}
+	}
+
+	private List<String> getMatchingHeaderNames(String pattern, Map<String, Object> headers) {
+		List<String> matchingHeaderNames = new ArrayList<String>();
+		if (headers != null) {
+			for (Map.Entry<String, Object> header: headers.entrySet()) {
+				if (PatternMatchUtils.simpleMatch(pattern,  header.getKey())) {
+					matchingHeaderNames.add(header.getKey());
+				}
+			}
+		}
+		return matchingHeaderNames;
 	}
 
 	/**


### PR DESCRIPTION
When headers are being removed based on pattern matching, both the new header names and the original header names need to be matched against the pattern. Previously, only new headers were being considered resulting in any matching original headers not being removed.
