### PR TITLE
Add configuration for message buffer size limit

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/config/MessageBrokerRegistry.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/config/MessageBrokerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,8 @@ public class MessageBrokerRegistry {
 	private String userDestinationPrefix;
 
 	private ChannelRegistration brokerChannelRegistration = new ChannelRegistration();
+
+	private Integer messageBufferSizeLimit;
 
 
 	public MessageBrokerRegistry(SubscribableChannel clientInboundChannel, MessageChannel clientOutboundChannel) {
@@ -119,6 +121,22 @@ public class MessageBrokerRegistry {
 		return this.brokerChannelRegistration;
 	}
 
+	/**
+	 * Configure the message buffer size limit in bytes.
+	 * @since 4.0.3
+	 */
+	public MessageBrokerRegistry setMessageBufferSizeLimit(Integer messageBufferSizeLimit) {
+		this.messageBufferSizeLimit = messageBufferSizeLimit;
+		return this;
+	}
+
+	/**
+	 * Get the message buffer size limit in bytes.
+	 * @since 4.0.3
+	 */
+	public Integer getMessageBufferSizeLimit() {
+		return this.messageBufferSizeLimit;
+	}
 
 	protected SimpleBrokerMessageHandler getSimpleBroker(SubscribableChannel brokerChannel) {
 		if ((this.simpleBrokerRegistration == null) && (this.brokerRelayRegistration == null)) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/BufferingStompDecoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/BufferingStompDecoder.java
@@ -31,7 +31,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 
 /**
- * A an extension of {@link org.springframework.messaging.simp.stomp.StompDecoder}
+ * An extension of {@link org.springframework.messaging.simp.stomp.StompDecoder}
  * that chunks any bytes remaining after a single full STOMP frame has been read.
  * The remaining bytes may contain more STOMP frames or an incomplete STOMP frame.
  *

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParser.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParser.java
@@ -124,8 +124,11 @@ class MessageBrokerBeanDefinitionParser implements BeanDefinitionParser {
 		beanName = registerBeanDef(beanDef, parserCxt, source);
 		RuntimeBeanReference userSessionRegistry = new RuntimeBeanReference(beanName);
 
+		String frameBufferSizeAttribute = element.getAttribute("message-buffer-size");
+		Integer messageBufferSizeLimit = frameBufferSizeAttribute.isEmpty() ? null : Integer.parseInt(frameBufferSizeAttribute);
+
 		RuntimeBeanReference subProtocolWsHandler = registerSubProtocolWebSocketHandler(
-				clientInChannel, clientOutChannel, userSessionRegistry, parserCxt, source);
+				clientInChannel, clientOutChannel, userSessionRegistry, messageBufferSizeLimit, parserCxt, source);
 
 		for(Element stompEndpointElem : DomUtils.getChildElementsByTagName(element, "stomp-endpoint")) {
 
@@ -228,10 +231,14 @@ class MessageBrokerBeanDefinitionParser implements BeanDefinitionParser {
 
 	private RuntimeBeanReference registerSubProtocolWebSocketHandler(
 			RuntimeBeanReference clientInChannel, RuntimeBeanReference clientOutChannel,
-			RuntimeBeanReference userSessionRegistry, ParserContext parserCxt, Object source) {
+			RuntimeBeanReference userSessionRegistry, Integer messageBufferSizeLimit,
+			ParserContext parserCxt, Object source) {
 
 		RootBeanDefinition stompHandlerDef = new RootBeanDefinition(StompSubProtocolHandler.class);
 		stompHandlerDef.getPropertyValues().add("userSessionRegistry", userSessionRegistry);
+		if(messageBufferSizeLimit != null) {
+			stompHandlerDef.getPropertyValues().add("messageBufferSizeLimit", messageBufferSizeLimit);
+		}
 		registerBeanDef(stompHandlerDef, parserCxt, source);
 
 		ConstructorArgumentValues cavs = new ConstructorArgumentValues();

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompEndpointRegistry.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebMvcStompEndpointRegistry.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.simp.user.UserSessionRegistry;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
@@ -57,7 +58,8 @@ public class WebMvcStompEndpointRegistry implements StompEndpointRegistry {
 
 
 	public WebMvcStompEndpointRegistry(WebSocketHandler webSocketHandler,
-			UserSessionRegistry userSessionRegistry, TaskScheduler defaultSockJsTaskScheduler) {
+			UserSessionRegistry userSessionRegistry, TaskScheduler defaultSockJsTaskScheduler,
+			MessageBrokerRegistry brokerRegistry) {
 
 		Assert.notNull(webSocketHandler);
 		Assert.notNull(userSessionRegistry);
@@ -67,6 +69,9 @@ public class WebMvcStompEndpointRegistry implements StompEndpointRegistry {
 		this.stompHandler = new StompSubProtocolHandler();
 		this.stompHandler.setUserSessionRegistry(userSessionRegistry);
 		this.sockJsScheduler = defaultSockJsTaskScheduler;
+		if(brokerRegistry.getMessageBufferSizeLimit() != null) {
+			this.stompHandler.setMessageBufferSizeLimit(brokerRegistry.getMessageBufferSizeLimit());
+		}
 	}
 
 	private static SubProtocolWebSocketHandler unwrapSubProtocolWebSocketHandler(WebSocketHandler webSocketHandler) {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebSocketMessageBrokerConfigurationSupport.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/WebSocketMessageBrokerConfigurationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,8 @@ public abstract class WebSocketMessageBrokerConfigurationSupport extends Abstrac
 	@Bean
 	public HandlerMapping stompWebSocketHandlerMapping() {
 		WebMvcStompEndpointRegistry registry = new WebMvcStompEndpointRegistry(
-				subProtocolWebSocketHandler(), userSessionRegistry(), messageBrokerSockJsTaskScheduler());
+				subProtocolWebSocketHandler(), userSessionRegistry(),
+				messageBrokerSockJsTaskScheduler(), getBrokerRegistry());
 		registerStompEndpoints(registry);
 		return registry.getHandlerMapping();
 	}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolHandler.java
@@ -76,16 +76,16 @@ public class StompSubProtocolHandler implements SubProtocolHandler {
 
 
 	/**
-	 * TODO
-	 * @param messageBufferSizeLimit
+	 * Set the message buffer size limit in bytes.
+	 * @since 4.0.3
 	 */
 	public void setMessageBufferSizeLimit(int messageBufferSizeLimit) {
 		this.messageBufferSizeLimit = messageBufferSizeLimit;
 	}
 
 	/**
-	 * TODO
-	 * @return
+	 * Get the message buffer size limit in bytes.
+	 * @since 4.0.3
 	 */
 	public int getMessageBufferSizeLimit() {
 		return this.messageBufferSizeLimit;

--- a/spring-websocket/src/main/resources/org/springframework/web/socket/config/spring-websocket-4.0.xsd
+++ b/spring-websocket/src/main/resources/org/springframework/web/socket/config/spring-websocket-4.0.xsd
@@ -575,6 +575,13 @@
                     ]]></xsd:documentation>
                 </xsd:annotation>
             </xsd:attribute>
+			<xsd:attribute name="message-buffer-size" type="xsd:int">
+				<xsd:annotation>
+					<xsd:documentation><![CDATA[
+	The message buffer size limit in bytes for simple messaging protocols like STOMP.
+                    ]]></xsd:documentation>
+				</xsd:annotation>
+			</xsd:attribute>
             <xsd:attribute name="order" type="xsd:token">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParserTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/MessageBrokerBeanDefinitionParserTests.java
@@ -114,6 +114,9 @@ public class MessageBrokerBeanDefinitionParserTests {
 				(StompSubProtocolHandler) subProtocolWsHandler.getProtocolHandlerMap().get("v12.stomp");
 		assertNotNull(stompHandler);
 
+		int messageBufferSizeLimit = (int)new  DirectFieldAccessor(stompHandler).getPropertyValue("messageBufferSizeLimit");
+		assertEquals(123, messageBufferSizeLimit);
+
 		httpRequestHandler = (HttpRequestHandler) suhm.getUrlMap().get("/test/**");
 		assertNotNull(httpRequestHandler);
 		assertThat(httpRequestHandler, Matchers.instanceOf(SockJsHttpRequestHandler.class));

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompEndpointRegistryTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebMvcStompEndpointRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.simp.user.DefaultUserSessionRegistry;
 import org.springframework.messaging.simp.user.UserSessionRegistry;
 import org.springframework.scheduling.TaskScheduler;
@@ -47,15 +47,19 @@ public class WebMvcStompEndpointRegistryTests {
 
 	private UserSessionRegistry userSessionRegistry;
 
+	private MessageBrokerRegistry messageBrokerRegistry;
+
 
 	@Before
 	public void setup() {
-		MessageChannel inChannel = Mockito.mock(MessageChannel.class);
+		SubscribableChannel inChannel = Mockito.mock(SubscribableChannel.class);
 		SubscribableChannel outChannel = Mockito.mock(SubscribableChannel.class);
 		this.webSocketHandler = new SubProtocolWebSocketHandler(inChannel, outChannel);
 		this.userSessionRegistry = new DefaultUserSessionRegistry();
+		this.messageBrokerRegistry = new MessageBrokerRegistry(inChannel, outChannel);
 		TaskScheduler taskScheduler = Mockito.mock(TaskScheduler.class);
-		this.registry = new WebMvcStompEndpointRegistry(webSocketHandler, userSessionRegistry, taskScheduler);
+		this.registry = new WebMvcStompEndpointRegistry(webSocketHandler, userSessionRegistry,
+				taskScheduler, messageBrokerRegistry);
 	}
 
 

--- a/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebSocketMessageBrokerConfigurationSupportTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/config/annotation/WebSocketMessageBrokerConfigurationSupportTests.java
@@ -24,11 +24,13 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.support.AbstractSubscribableChannel;
 import org.springframework.messaging.support.ExecutorSubscribableChannel;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -41,8 +43,11 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TestWebSocketSession;
+import org.springframework.web.socket.messaging.StompSubProtocolHandler;
 import org.springframework.web.socket.messaging.StompTextMessageBuilder;
+import org.springframework.web.socket.messaging.SubProtocolHandler;
 import org.springframework.web.socket.messaging.SubProtocolWebSocketHandler;
 
 import static org.junit.Assert.*;
@@ -80,9 +85,11 @@ public class WebSocketMessageBrokerConfigurationSupportTests {
 
 		TestChannel channel = this.config.getBean("clientInboundChannel", TestChannel.class);
 		SubProtocolWebSocketHandler webSocketHandler = this.config.getBean(SubProtocolWebSocketHandler.class);
+		WebSocketSession session = new TestWebSocketSession("s1");
 
+		webSocketHandler.afterConnectionEstablished(session);
 		TextMessage textMessage = StompTextMessageBuilder.create(StompCommand.SEND).headers("destination:/foo").build();
-		webSocketHandler.handleMessage(new TestWebSocketSession(), textMessage);
+		webSocketHandler.handleMessage(session, textMessage);
 
 		Message<?> message = channel.messages.get(0);
 		StompHeaderAccessor headers = StompHeaderAccessor.wrap(message);
@@ -98,6 +105,18 @@ public class WebSocketMessageBrokerConfigurationSupportTests {
 
 		assertEquals(1, handlers.size());
 		assertTrue(handlers.iterator().next() instanceof SubProtocolWebSocketHandler);
+	}
+
+	@Test
+	public void maxFrameBufferSize() {
+		SubProtocolWebSocketHandler subProtocolWebSocketHandler = this.config.getBean("subProtocolWebSocketHandler", SubProtocolWebSocketHandler.class);
+
+		List<SubProtocolHandler> protocolHandlers = subProtocolWebSocketHandler.getProtocolHandlers();
+		for(SubProtocolHandler protocolHandler : protocolHandlers) {
+			assertTrue(protocolHandler instanceof StompSubProtocolHandler);
+			DirectFieldAccessor protocolHandlerFieldAccessor = new DirectFieldAccessor(protocolHandler);
+			assertEquals(123, protocolHandlerFieldAccessor.getPropertyValue("messageBufferSizeLimit"));
+		}
 	}
 
 
@@ -127,6 +146,11 @@ public class WebSocketMessageBrokerConfigurationSupportTests {
 		@Override
 		public void registerStompEndpoints(StompEndpointRegistry registry) {
 			registry.addEndpoint("/simpleBroker");
+		}
+
+		@Override
+		public void configureMessageBroker(MessageBrokerRegistry registry) {
+			registry.setMessageBufferSizeLimit(123);
 		}
 
 	}

--- a/spring-websocket/src/test/java/org/springframework/web/socket/handler/TestWebSocketSession.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/handler/TestWebSocketSession.java
@@ -62,6 +62,12 @@ public class TestWebSocketSession implements WebSocketSession {
 
 	private HttpHeaders headers;
 
+	public TestWebSocketSession() {
+	}
+
+	public TestWebSocketSession(String id) {
+		this.id = id;
+	}
 
 	@Override
 	public String getId() {

--- a/spring-websocket/src/test/java/org/springframework/web/socket/messaging/StompSubProtocolHandlerTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/messaging/StompSubProtocolHandlerTests.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -130,8 +131,9 @@ public class StompSubProtocolHandlerTests {
 
 		assertEquals(1, this.session.getSentMessages().size());
 		TextMessage textMessage = (TextMessage) this.session.getSentMessages().get(0);
-		Message<?> message = new StompDecoder().decode(ByteBuffer.wrap(textMessage.getPayload().getBytes()));
-		StompHeaderAccessor replyHeaders = StompHeaderAccessor.wrap(message);
+		List<Message<byte[]>> messages = new StompDecoder().decode(ByteBuffer.wrap(textMessage.getPayload().getBytes()));
+		assertEquals(1, messages.size());
+		StompHeaderAccessor replyHeaders = StompHeaderAccessor.wrap(messages.get(0));
 
 		assertEquals(StompCommand.CONNECTED, replyHeaders.getCommand());
 		assertEquals("1.1", replyHeaders.getVersion());
@@ -161,6 +163,7 @@ public class StompSubProtocolHandlerTests {
 		TextMessage textMessage = StompTextMessageBuilder.create(StompCommand.CONNECT).headers(
 				"login:guest", "passcode:guest", "accept-version:1.1,1.0", "heart-beat:10000,10000").build();
 
+		this.protocolHandler.afterSessionStarted(this.session, this.channel);
 		this.protocolHandler.handleMessageFromClient(this.session, textMessage, this.channel);
 
 		verify(this.channel).send(this.messageCaptor.capture());

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-simple.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-simple.xml
@@ -4,7 +4,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket-4.0.xsd">
 
-    <websocket:message-broker application-destination-prefix="/app" user-destination-prefix="/personal">
+    <websocket:message-broker application-destination-prefix="/app" user-destination-prefix="/personal" message-buffer-size="123">
         <websocket:stomp-endpoint path=" /foo,/bar">
             <websocket:handshake-handler ref="myHandler"/>
         </websocket:stomp-endpoint>

--- a/src/asciidoc/index.adoc
+++ b/src/asciidoc/index.adoc
@@ -37437,7 +37437,8 @@ The Spring Framework provides support for using STOMP over WebSocket through
 the +spring-messaging+ and +spring-websocket+ modules. It's easy to enable it.
 
 Here is an example of configuring a STOMP WebSocket endpoint with SockJS fallback
-options. The endpoint is available for clients to connect to at URL path `/portfolio`:
+options. The endpoint is available for clients to connect to at URL path `/app/portfolio`.
+It is configured with a 1 Mbytes message buffer size limit (64 Kbytes by default):
 
 [source,java,indent=0]
 [subs="verbatim,quotes"]
@@ -37448,6 +37449,13 @@ options. The endpoint is available for clients to connect to at URL path `/portf
 	@Configuration
 	@EnableWebSocketMessageBroker
 	public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+		@Override
+        public void configureMessageBroker(MessageBrokerRegistry config) {
+            config.setApplicationDestinationPrefixes("/app")
+                .setMessageBufferSizeLimit(1024*1024)
+                .enableSimpleBroker("/queue", "/topic");
+        }
 
 		@Override
 		public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -37473,10 +37481,11 @@ XML configuration equivalent:
 			http://www.springframework.org/schema/websocket
 			http://www.springframework.org/schema/websocket/spring-websocket-4.0.xsd">
 
-		<websocket:message-broker>
+		<websocket:message-broker application-destination-prefix="/app" message-buffer-size="1048576">
 			<websocket:stomp-endpoint path="/portfolio">
 				<websocket:sockjs/>
 			</websocket:stomp-endpoint>
+			<websocket:simple-broker prefix="/queue, /topic"/>
 			...
 		</websocket:message-broker>
 


### PR DESCRIPTION
BufferingStompDecoder message buffer size limit can now be configured
with JavaConfig MessageBrokerRegistry.setMessageBufferSizeLimit() or
with XML <websocket:message-brocker message-buffer-size="">.

Issue: SPR-11527

I also fixed some failing tests.
